### PR TITLE
fix: remove duplicate sale button

### DIFF
--- a/frontend/src/app/(dashboard)/ventas/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/ventas/[id]/page.tsx
@@ -41,10 +41,6 @@ const getDasboardTitle = (sale: SaleByIdQuery['saleById'] | undefined) => {
                     {sale.client.firstName} {sale.client.lastName} / #{sale.id}
                 </span>
             </div>
-
-            <Button asChild>
-                <Link href={`/ventas/add?duplicateId=${sale.id}`}>Duplicar venta</Link>
-            </Button>
         </div>
     );
 };


### PR DESCRIPTION
The "Duplicar venta" button was removed from the sales page to align with the updated scope of the project.

