### PR TITLE
Redondear descuento en "calculateDiscountAmountFromPercentage"

### DIFF
--- a/frontend/src/modules/editors/sale/sale-form-editor-orders.tsx
+++ b/frontend/src/modules/editors/sale/sale-form-editor-orders.tsx
@@ -34,7 +34,7 @@ const calculateDiscountAmountFromPercentage = ({
     subtotal,
     percentage,
 }: CalculateDiscountFromPercentageOptions) => {
-    return subtotal * (percentage / 100);
+    return Math.round(subtotal * (percentage / 100));
 };
 
 type CalculateDiscountFromAmountOptions = {


### PR DESCRIPTION
Este cambio arregla un error que no dejaba crear ventas si el calculo del monto de descuento daba un numero flotante